### PR TITLE
:sparkles: BA-0001-create-users-roles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <plugins>
       <plugin>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>2.6.7</version>
         <configuration>
           <excludes>
             <exclude>
@@ -26,10 +27,6 @@
     </dependency>
     <dependency>
       <artifactId>spring-boot-starter-security</artifactId>
-      <groupId>org.springframework.boot</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>spring-boot-starter-validation</artifactId>
       <groupId>org.springframework.boot</groupId>
     </dependency>
     <dependency>
@@ -56,6 +53,7 @@
     <dependency>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
       <groupId>de.flapdoodle.embed</groupId>
+      <version>3.4.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -63,10 +61,29 @@
       <groupId>io.projectreactor</groupId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <artifactId>spring-security-test</artifactId>
-      <groupId>org.springframework.security</groupId>
-      <scope>test</scope>
+      <artifactId>spring-data-mongodb-encrypt</artifactId>
+      <groupId>com.bol</groupId>
+      <version>2.8.0</version>
+    </dependency>
+
+    <dependency>
+      <artifactId>jjwt-api</artifactId>
+      <groupId>io.jsonwebtoken</groupId>
+      <version>${jjwt.version}</version>
+    </dependency>
+    <dependency>
+      <artifactId>jjwt-impl</artifactId>
+      <groupId>io.jsonwebtoken</groupId>
+      <scope>runtime</scope>
+      <version>${jjwt.version}</version>
+    </dependency>
+    <dependency>
+      <artifactId>jjwt-jackson</artifactId>
+      <groupId>io.jsonwebtoken</groupId>
+      <scope>runtime</scope>
+      <version>${jjwt.version}</version>
     </dependency>
 
     <dependency>
@@ -87,6 +104,7 @@
   </parent>
   <properties>
     <java.version>17</java.version>
+    <jjwt.version>0.11.5</jjwt.version>
   </properties>
 
   <version>0.0.1-SNAPSHOT</version>

--- a/src/main/java/com/paperz/bikesanonymous/bootstrap/InitUsers.java
+++ b/src/main/java/com/paperz/bikesanonymous/bootstrap/InitUsers.java
@@ -1,0 +1,46 @@
+package com.paperz.bikesanonymous.bootstrap;
+
+import com.paperz.bikesanonymous.domain.Role;
+import com.paperz.bikesanonymous.domain.User;
+import com.paperz.bikesanonymous.repositories.UserRepository;
+import com.paperz.bikesanonymous.security.PBKDF2Encoder;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+@AllArgsConstructor
+@Component
+@Slf4j
+public class InitUsers implements CommandLineRunner {
+
+  private final UserRepository userRepository;
+  private PBKDF2Encoder passwordEncoder;
+
+  @Override
+  public void run(String... args) {
+    userRepository
+        .deleteAll()
+        .thenMany(
+            Flux.just(
+                    User.builder()
+                        .username("user@ba.com")
+                        .password(passwordEncoder.encode("pass"))
+                        .enabled(true)
+                        .roles(Set.of(Role.ROLE_USER))
+                        .build(),
+                    User.builder()
+                        .username("admin@ba.com")
+                        .password(passwordEncoder.encode("pass"))
+                        .enabled(true)
+                        .roles(Set.of(Role.ROLE_ADMIN))
+                        .build())
+                .flatMap(userRepository::save))
+        .subscribe(
+            null,
+            null,
+            () -> userRepository.findAll().subscribe(user -> log.info(user.toString())));
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/configurations/WebSecurityConfig.java
+++ b/src/main/java/com/paperz/bikesanonymous/configurations/WebSecurityConfig.java
@@ -1,0 +1,59 @@
+package com.paperz.bikesanonymous.configurations;
+
+import com.paperz.bikesanonymous.security.AuthenticationManager;
+import com.paperz.bikesanonymous.security.SecurityContextRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import reactor.core.publisher.Mono;
+
+@AllArgsConstructor
+@EnableWebFluxSecurity
+@EnableReactiveMethodSecurity
+public class WebSecurityConfig {
+
+  private AuthenticationManager authenticationManager;
+  private SecurityContextRepository securityContextRepository;
+
+  @Bean
+  public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+    return http.exceptionHandling()
+        .authenticationEntryPoint(
+            (swe, e) ->
+                Mono.fromRunnable(() -> swe.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED)))
+        .accessDeniedHandler(
+            (swe, e) ->
+                Mono.fromRunnable(() -> swe.getResponse().setStatusCode(HttpStatus.FORBIDDEN)))
+        .and()
+        .csrf()
+        .disable()
+        .formLogin()
+        .disable()
+        .httpBasic()
+        .disable()
+        .authenticationManager(authenticationManager)
+        .securityContextRepository(securityContextRepository)
+        .authorizeExchange()
+        .pathMatchers(HttpMethod.OPTIONS)
+        .permitAll()
+        .pathMatchers("/login", "/register")
+        .permitAll()
+        .pathMatchers(
+            "/v3/api-docs/**",
+            "/configuration/ui",
+            "/swagger-resources/**",
+            "/configuration/security",
+            "/swagger-ui.html",
+            "/webjars/**")
+        .permitAll()
+        .anyExchange()
+        .authenticated()
+        .and()
+        .build();
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/controllers/UserController.java
+++ b/src/main/java/com/paperz/bikesanonymous/controllers/UserController.java
@@ -1,0 +1,67 @@
+package com.paperz.bikesanonymous.controllers;
+
+import com.paperz.bikesanonymous.domain.auth.AuthMessage;
+import com.paperz.bikesanonymous.domain.auth.AuthRequest;
+import com.paperz.bikesanonymous.domain.auth.AuthResponse;
+import com.paperz.bikesanonymous.security.PBKDF2Encoder;
+import com.paperz.bikesanonymous.services.UserService;
+import com.paperz.bikesanonymous.utils.JWTUtil;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@AllArgsConstructor
+@RestController
+public class UserController {
+  private JWTUtil jwtUtil;
+  private PBKDF2Encoder passwordEncoder;
+  private UserService userService;
+
+  @PostMapping("/login")
+  public Mono<ResponseEntity<AuthResponse>> login(@RequestBody AuthRequest ar) {
+    return userService
+        .findByUsername(ar.getUsername())
+        .filter(
+            userDetails ->
+                passwordEncoder.encode(ar.getPassword()).equals(userDetails.getPassword()))
+        .map(
+            userDetails ->
+                ResponseEntity.ok(
+                    AuthResponse.builder().token(jwtUtil.generateToken(userDetails)).build()))
+        .switchIfEmpty(Mono.just(ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()));
+  }
+
+  @PostMapping("/register")
+  public Mono<ResponseEntity<AuthResponse>> register(@RequestBody AuthRequest ar) {
+    return userService
+        .createUser(ar)
+        .map(
+            user ->
+                ResponseEntity.ok(
+                    AuthResponse.builder().token(jwtUtil.generateToken(user)).build()));
+  }
+
+  @GetMapping("/hello/user")
+  @PreAuthorize("hasRole('USER')")
+  public Mono<ResponseEntity<AuthMessage>> helloUser() {
+    return Mono.just(ResponseEntity.ok(AuthMessage.builder().content("Hello user!").build()));
+  }
+
+  @GetMapping("/hello/admin")
+  @PreAuthorize("hasRole('ADMIN')")
+  public Mono<ResponseEntity<AuthMessage>> helloAdmin() {
+    return Mono.just(ResponseEntity.ok(AuthMessage.builder().content("Hello admin!").build()));
+  }
+
+  @GetMapping("/hello")
+  @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+  public Mono<ResponseEntity<AuthMessage>> hello() {
+    return Mono.just(ResponseEntity.ok(AuthMessage.builder().content("Hello!").build()));
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/domain/Role.java
+++ b/src/main/java/com/paperz/bikesanonymous/domain/Role.java
@@ -1,0 +1,6 @@
+package com.paperz.bikesanonymous.domain;
+
+public enum Role {
+  ROLE_USER,
+  ROLE_ADMIN
+}

--- a/src/main/java/com/paperz/bikesanonymous/domain/User.java
+++ b/src/main/java/com/paperz/bikesanonymous/domain/User.java
@@ -1,0 +1,72 @@
+package com.paperz.bikesanonymous.domain;
+
+import java.util.Collection;
+import java.util.Set;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Document
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Getter
+public class User implements UserDetails {
+
+  @Indexed(unique = true)
+  private String username;
+
+  @NotBlank private String password;
+  @Builder.Default private boolean enabled = true;
+
+  @Builder.Default
+  @Size(min = 1)
+  private Set<Role> roles = Set.of(Role.ROLE_USER);
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return this.roles.stream()
+        .map(auth -> new SimpleGrantedAuthority(auth.name()))
+        .toList();
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return false;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/domain/auth/AuthMessage.java
+++ b/src/main/java/com/paperz/bikesanonymous/domain/auth/AuthMessage.java
@@ -1,0 +1,10 @@
+package com.paperz.bikesanonymous.domain.auth;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AuthMessage {
+  private String content;
+}

--- a/src/main/java/com/paperz/bikesanonymous/domain/auth/AuthRequest.java
+++ b/src/main/java/com/paperz/bikesanonymous/domain/auth/AuthRequest.java
@@ -1,0 +1,11 @@
+package com.paperz.bikesanonymous.domain.auth;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AuthRequest {
+  private String username;
+  private String password;
+}

--- a/src/main/java/com/paperz/bikesanonymous/domain/auth/AuthResponse.java
+++ b/src/main/java/com/paperz/bikesanonymous/domain/auth/AuthResponse.java
@@ -1,0 +1,10 @@
+package com.paperz.bikesanonymous.domain.auth;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AuthResponse {
+  private String token;
+}

--- a/src/main/java/com/paperz/bikesanonymous/handlers/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/com/paperz/bikesanonymous/handlers/GlobalErrorWebExceptionHandler.java
@@ -1,0 +1,58 @@
+package com.paperz.bikesanonymous.handlers;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.reactive.error.DefaultErrorAttributes;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+@Order(-2)
+@Slf4j
+public class GlobalErrorWebExceptionHandler extends AbstractErrorWebExceptionHandler {
+
+  public GlobalErrorWebExceptionHandler(
+      DefaultErrorAttributes defaultErrorAttributes,
+      ApplicationContext applicationContext,
+      ServerCodecConfigurer serverCodecConfigurer) {
+    super(defaultErrorAttributes, new WebProperties.Resources(), applicationContext);
+    super.setMessageWriters(serverCodecConfigurer.getWriters());
+    super.setMessageReaders(serverCodecConfigurer.getReaders());
+  }
+
+  @Override
+  protected RouterFunction<ServerResponse> getRoutingFunction(
+      final ErrorAttributes errorAttributes) {
+    return RouterFunctions.route(RequestPredicates.all(), this::renderErrorResponse);
+  }
+
+  private Mono<ServerResponse> renderErrorResponse(final ServerRequest request) {
+    ErrorAttributeOptions options =
+        ErrorAttributeOptions.defaults()
+            .including(ErrorAttributeOptions.Include.MESSAGE)
+            .including(ErrorAttributeOptions.Include.STACK_TRACE);
+    final Map<String, Object> errorPropertiesMap = getErrorAttributes(request, options);
+
+    log.error((String) errorPropertiesMap.get("trace"));
+    errorPropertiesMap.remove("trace");
+
+    return ServerResponse.status(HttpStatus.BAD_REQUEST)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(BodyInserters.fromValue(errorPropertiesMap));
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/repositories/UserRepository.java
+++ b/src/main/java/com/paperz/bikesanonymous/repositories/UserRepository.java
@@ -1,0 +1,12 @@
+package com.paperz.bikesanonymous.repositories;
+
+import com.paperz.bikesanonymous.domain.User;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Mono;
+
+public interface UserRepository extends ReactiveMongoRepository<User, String> {
+
+  Mono<User> findUserByUsername(String username);
+
+  Mono<Boolean> existsUserByUsername(String username);
+}

--- a/src/main/java/com/paperz/bikesanonymous/security/AuthenticationManager.java
+++ b/src/main/java/com/paperz/bikesanonymous/security/AuthenticationManager.java
@@ -1,0 +1,38 @@
+package com.paperz.bikesanonymous.security;
+
+import com.paperz.bikesanonymous.utils.JWTUtil;
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@AllArgsConstructor
+public class AuthenticationManager implements ReactiveAuthenticationManager {
+
+  private JWTUtil jwtUtil;
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Mono<Authentication> authenticate(Authentication authentication) {
+    String authToken = authentication.getCredentials().toString();
+    String username = jwtUtil.getUsernameFromToken(authToken);
+    return Mono.just(jwtUtil.validateToken(authToken))
+        .filter(valid -> valid)
+        .switchIfEmpty(Mono.empty())
+        .map(
+            valid -> {
+              Claims claims = jwtUtil.getAllClaimsFromToken(authToken);
+              List<String> rolesMap = claims.get("role", List.class);
+              return new UsernamePasswordAuthenticationToken(
+                  username,
+                  null,
+                  rolesMap.stream().map(SimpleGrantedAuthority::new).toList());
+            });
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/security/PBKDF2Encoder.java
+++ b/src/main/java/com/paperz/bikesanonymous/security/PBKDF2Encoder.java
@@ -1,0 +1,45 @@
+package com.paperz.bikesanonymous.security;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class PBKDF2Encoder implements PasswordEncoder {
+
+  @Value("${password.encoder.secret}")
+  private String secret;
+
+  @Value("${password.encoder.iteration}")
+  private Integer iteration;
+
+  @Value("${password.encoder.keylength}")
+  private Integer keyLength;
+
+  @Override
+  public String encode(CharSequence cs) {
+    try {
+      byte[] result =
+          SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512")
+              .generateSecret(
+                  new PBEKeySpec(
+                      cs.toString().toCharArray(), secret.getBytes(), iteration, keyLength))
+              .getEncoded();
+      return Base64.getEncoder().encodeToString(result);
+    } catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Override
+  public boolean matches(CharSequence cs, String string) {
+    return encode(cs).equals(string);
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/security/SecurityContextRepository.java
+++ b/src/main/java/com/paperz/bikesanonymous/security/SecurityContextRepository.java
@@ -1,0 +1,36 @@
+package com.paperz.bikesanonymous.security;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+@AllArgsConstructor
+public class SecurityContextRepository implements ServerSecurityContextRepository {
+
+  private AuthenticationManager authenticationManager;
+
+  @Override
+  public Mono<Void> save(ServerWebExchange swe, SecurityContext sc) {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  @Override
+  public Mono<SecurityContext> load(ServerWebExchange swe) {
+    return Mono.justOrEmpty(swe.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION))
+        .filter(authHeader -> authHeader.startsWith("Bearer "))
+        .flatMap(
+            authHeader -> {
+              String authToken = authHeader.substring(7);
+              Authentication auth = new UsernamePasswordAuthenticationToken(authToken, authToken);
+              return this.authenticationManager.authenticate(auth).map(SecurityContextImpl::new);
+            });
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/services/UserService.java
+++ b/src/main/java/com/paperz/bikesanonymous/services/UserService.java
@@ -1,0 +1,41 @@
+package com.paperz.bikesanonymous.services;
+
+import com.paperz.bikesanonymous.domain.User;
+import com.paperz.bikesanonymous.domain.auth.AuthRequest;
+import com.paperz.bikesanonymous.repositories.UserRepository;
+import com.paperz.bikesanonymous.security.PBKDF2Encoder;
+import lombok.AllArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+@Service
+@AllArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+  private PBKDF2Encoder passwordEncoder;
+
+  public Mono<User> findByUsername(String username) {
+    return userRepository.findUserByUsername(username);
+  }
+
+  public Mono<Boolean> userExists(String username) {
+    return userRepository.existsUserByUsername(username);
+  }
+
+  public Mono<User> createUser(AuthRequest authRequest) {
+    User newUser =
+        User.builder()
+            .username(authRequest.getUsername())
+            .password(passwordEncoder.encode(authRequest.getPassword()))
+            .build();
+    return userRepository
+        .insert(newUser)
+        .onErrorMap(
+            DuplicateKeyException.class,
+            e -> new ResponseStatusException(HttpStatus.CONFLICT, "Username already exists."));
+  }
+}

--- a/src/main/java/com/paperz/bikesanonymous/utils/JWTUtil.java
+++ b/src/main/java/com/paperz/bikesanonymous/utils/JWTUtil.java
@@ -1,0 +1,71 @@
+package com.paperz.bikesanonymous.utils;
+
+import com.paperz.bikesanonymous.domain.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JWTUtil {
+
+  @Value("${jjwt.secret}")
+  private String secret;
+
+  @Value("${jjwt.expiration}")
+  private String expirationTime;
+
+  private Key key;
+
+  @PostConstruct
+  public void init() {
+    this.key = Keys.hmacShaKeyFor(secret.getBytes());
+  }
+
+  public Claims getAllClaimsFromToken(String token) {
+    return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+  }
+
+  public String getUsernameFromToken(String token) {
+    return getAllClaimsFromToken(token).getSubject();
+  }
+
+  public Date getExpirationDateFromToken(String token) {
+    return getAllClaimsFromToken(token).getExpiration();
+  }
+
+  private Boolean isTokenExpired(String token) {
+    final Date expiration = getExpirationDateFromToken(token);
+    return expiration.before(new Date());
+  }
+
+  public String generateToken(User user) {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("role", user.getRoles());
+    return doGenerateToken(claims, user.getUsername());
+  }
+
+  private String doGenerateToken(Map<String, Object> claims, String username) {
+    long expirationTimeLong = Long.parseLong(expirationTime);
+    final Date createdDate = new Date();
+    final Date expirationDate = new Date(createdDate.getTime() + expirationTimeLong * 1000);
+
+    return Jwts.builder()
+        .setClaims(claims)
+        .setSubject(username)
+        .setIssuedAt(createdDate)
+        .setExpiration(expirationDate)
+        .signWith(key)
+        .compact();
+  }
+
+  public Boolean validateToken(String token) {
+    return !isTokenExpired(token);
+  }
+}

--- a/src/test/java/com/paperz/bikesanonymous/BikesAnonymousApplicationTests.java
+++ b/src/test/java/com/paperz/bikesanonymous/BikesAnonymousApplicationTests.java
@@ -1,5 +1,6 @@
 package com.paperz.bikesanonymous;
 
+import com.mongodb.assertions.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -7,5 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 class BikesAnonymousApplicationTests {
 
   @Test
-  void contextLoads() {}
+  void contextLoads() {
+    Assertions.assertNotNull(this);
+  }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,6 @@
+# suppress inspection "SpringBootApplicationProperties" for whole file
+# EMBEDDED MONGO
+spring.mongodb.embedded.version=5.0.5
 # MONGO CONFIG
 spring.data.mongodb.auto-index-creation=true
 # AUTHENTICATION


### PR DESCRIPTION
Finished minimal functionality. Pending tests and refactor. Do them in another branch.

### User story BA-0001:
User document should be:
- username: string
- password: encrypted string
- roles: list<roles>{cyclist, admin}

Allow the users to authenticate via /login endpoint, obtain an JWT and use it to access other endpoints that they are able to access according to their permission level.

They can also register using the /register endpoint.